### PR TITLE
finished items.

### DIFF
--- a/server/api.py
+++ b/server/api.py
@@ -31,6 +31,14 @@ def item(iid):
     except ValueError as v:
         return v
 
+def items(page=1, limit=100):
+    # Use the query "(*:*)" to return all indexed items.
+    r = search('(*:*)', page=page, limit=limit)
+    items = []
+    for doc in r.get('response', {}).get('docs', []):
+        items.append(doc['identifier'])
+    return items
+
 def download(iid, filename):
     r = requests.get('%s/download/%s/%s' % (API_BASEURL, iid, filename),
                      stream=True, allow_redirects=True)
@@ -71,6 +79,3 @@ def search(query, page=1, limit=100):
                                 'fl[]': 'identifier',
                                 'output': 'json'
                                 }).json()
-
-    
-

--- a/server/views/apis/v1/items.py
+++ b/server/views/apis/v1/items.py
@@ -10,15 +10,18 @@
     :license: see LICENSE for more details.
 """
 
-from flask import render_template, Response
+from flask import render_template, Response, request
 from flask.views import MethodView
 from views import rest_api
-from api import item, mimetype, download
+from api import items, item, mimetype, download
 
 class Items(MethodView):
     @rest_api
     def get(self):
-        return []
+        i = request.args
+        limit = i.get('limit', 50)
+        page = i.get('page', 1)
+        return items(page, limit)
 
 class Item(MethodView):
     @rest_api


### PR DESCRIPTION
Added items endpoint. The Solr search query `(*:*)` will return all indexed documents. `items()` just uses `search()` to return all indexed Items on Archive.org. The response is a list of identifiers.